### PR TITLE
Migration to Enums and Interfaces

### DIFF
--- a/custom_components/pun_sensor/__init__.py
+++ b/custom_components/pun_sensor/__init__.py
@@ -1,5 +1,6 @@
 """Prezzi PUN del mese"""
 
+# pylint: disable= E1101
 from datetime import timedelta
 import logging
 from zoneinfo import ZoneInfo
@@ -29,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
 
     # Carica le dipendenze di holidays in background
     with async_pause_setup(hass, SetupPhases.WAIT_IMPORT_PACKAGES):
-        await hass.async_add_import_executor_job(holidays.IT)
+        await hass.async_add_import_executor_job(holidays.IT)  # type: ignore
 
     # Salva il coordinator nella configurazione
     coordinator = PUNDataUpdateCoordinator(hass, config)
@@ -74,10 +75,11 @@ async def update_listener(hass: HomeAssistant, config: ConfigEntry) -> None:
         coordinator.scan_hour = config.options[CONF_SCAN_HOUR]
 
         # Calcola la data della prossima esecuzione (all'ora definita)
-        next_update_pun = dt_util.now().replace(
+        now = dt_util.now()
+        next_update_pun = now.replace(
             hour=coordinator.scan_hour, minute=0, second=0, microsecond=0
         )
-        if next_update_pun.hour < dt_util.now().hour:
+        if next_update_pun.hour < now.hour:
             # Se l'ora impostata è minore della corrente, schedula a domani
             # (perciò se è uguale esegue subito l'aggiornamento)
             next_update_pun = next_update_pun + timedelta(days=1)
@@ -114,4 +116,3 @@ async def update_listener(hass: HomeAssistant, config: ConfigEntry) -> None:
         coordinator.schedule_token = async_call_later(
             coordinator.hass, timedelta(seconds=5), coordinator.update_pun
         )
-

--- a/custom_components/pun_sensor/config_flow.py
+++ b/custom_components/pun_sensor/config_flow.py
@@ -1,3 +1,5 @@
+"""config flows for pun_sensor"""
+
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -71,10 +73,10 @@ class PUNConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Schema dati di configurazione (con default fissi)
         data_schema = {
-            vol.Required(CONF_SCAN_HOUR, default=1): vol.All(
+            vol.Required(CONF_SCAN_HOUR, default=1): vol.All(  # type: ignore
                 cv.positive_int, vol.Range(min=0, max=23)
             ),
-            vol.Optional(CONF_ACTUAL_DATA_ONLY, default=False): cv.boolean,
+            vol.Optional(CONF_ACTUAL_DATA_ONLY, default=False): cv.boolean,  # type: ignore
         }
 
         # Mostra la schermata di configurazione, con gli eventuali errori

--- a/custom_components/pun_sensor/coordinator.py
+++ b/custom_components/pun_sensor/coordinator.py
@@ -27,13 +27,9 @@ from .const import (
     DOMAIN,
     EVENT_UPDATE_FASCIA,
     EVENT_UPDATE_PUN,
-    PUN_FASCIA_F1,
-    PUN_FASCIA_F2,
-    PUN_FASCIA_F3,
-    PUN_FASCIA_F23,
-    PUN_FASCIA_MONO,
 )
 from .utils import get_fascia, get_next_date, extract_xml
+from .interfaces import PunData, Fascia, PunValues
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -67,10 +63,10 @@ class PUNDataUpdateCoordinator(DataUpdateCoordinator):
         # Inizializza i valori di default
         self.web_retries = 0
         self.schedule_token = None
-        self.pun = [0.0, 0.0, 0.0, 0.0, 0.0]
-        self.orari = [0, 0, 0, 0, 0]
-        self.fascia_corrente: int | None = None
-        self.fascia_successiva: int | None = None
+        self.pun_data: PunData = PunData()
+        self.pun_values: PunValues = PunValues()
+        self.fascia_corrente: Fascia | None = None
+        self.fascia_successiva: Fascia | None = None
         self.prossimo_cambio_fascia: datetime | None = None
         self.termine_prossima_fascia: datetime | None = None
 
@@ -151,38 +147,42 @@ class PUNDataUpdateCoordinator(DataUpdateCoordinator):
             ", ".join(str(fn) for fn in archive.namelist()),
         )
         # Estrae i dati dall'archivio
-        extracted_data = extract_xml(archive)
+        self.pun_data = extract_xml(archive, self.pun_data)
 
-        # Salva i risultati nel coordinator
-        self.orari[PUN_FASCIA_MONO] = len(extracted_data[PUN_FASCIA_MONO])
-        self.orari[PUN_FASCIA_F1] = len(extracted_data[PUN_FASCIA_F1])
-        self.orari[PUN_FASCIA_F2] = len(extracted_data[PUN_FASCIA_F2])
-        self.orari[PUN_FASCIA_F3] = len(extracted_data[PUN_FASCIA_F3])
-        # iter on orari
-        for i in range(5):  # stop is omitted
-            if self.orari[i] > 0:
-                self.pun[i] = mean(extracted_data[i])
-            # fascia F23
-            if i == 4:
-                # Calcola la fascia F23 (a partire da F2 ed F3)
-                # NOTA: la motivazione del calcolo è oscura ma sembra corretta; vedere:
-                # https://github.com/virtualdj/pun_sensor/issues/24#issuecomment-1829846806
-                if (self.orari[PUN_FASCIA_F2] and self.orari[PUN_FASCIA_F3]) > 0:
-                    # Esistono dati sia per F2 che per F3
-                    self.orari[PUN_FASCIA_F23] = (
-                        self.orari[PUN_FASCIA_F2] + self.orari[PUN_FASCIA_F3]
+        # per ogni fascia, calcola il valore del pun
+        for fascia, value_list in self.pun_data.pun.items():
+            # se abbiamo valori nella fascia
+            if len(value_list) > 0:
+                # calcola la media dei pun e aggiorna il valore del pun attuale per la fascia corrispondente
+                self.pun_values.value[fascia] = mean(self.pun_data.pun[fascia])
+            else:
+                # non avendo dati reali per la fascia F23 la length sara' 0, quindi facciamo un catch qua
+                if fascia == Fascia.F23:
+                    # Calcola la fascia F23 (a partire da F2 ed F3)
+                    # NOTA: la motivazione del calcolo è oscura ma sembra corretta; vedere:
+                    # https://github.com/virtualdj/pun_sensor/issues/24#issuecomment-1829846806
+                    # Se esistono dati otteniamo un valore, se non abbiamo i dati di una delle 2
+                    self.pun_values.value[Fascia.F23] = (
+                        (
+                            0.46 * self.pun_values.value[Fascia.F2]
+                            + 0.54 * self.pun_values.value[Fascia.F3]
+                        )
+                        if (
+                            len(self.pun_data.pun[Fascia.F2])
+                            + len(self.pun_data.pun[Fascia.F3])
+                        )
+                        > 0
+                        else 0
                     )
-                    self.pun[PUN_FASCIA_F23] = (
-                        0.46 * self.pun[PUN_FASCIA_F2] + 0.54 * self.pun[PUN_FASCIA_F3]
-                    )
-                else:
-                    # Devono esserci dati sia per F2 che per F3 affinché il risultato sia valido
-                    self.orari[PUN_FASCIA_F23] = 0
-                    self.pun[PUN_FASCIA_F23] = 0
 
         # Logga i dati
-        _LOGGER.debug("Numero di dati: " + ", ".join(str(i) for i in self.orari))
-        _LOGGER.debug("Valori PUN: " + ", ".join(str(f) for f in self.pun))
+        _LOGGER.debug(
+            "Numero di dati: %s",
+            ", ".join(str(len(i)) for i in self.pun_data.pun.values()),
+        )
+        _LOGGER.debug(
+            "Valori PUN: %s", ", ".join(str(f) for f in self.pun_values.value.values())
+        )
         return
 
     async def update_fascia(self, now=None):

--- a/custom_components/pun_sensor/interfaces.py
+++ b/custom_components/pun_sensor/interfaces.py
@@ -1,0 +1,42 @@
+from enum import Enum
+
+
+class PunData:
+    def __init__(self) -> None:
+        self.orari: dict[Fascia, int]
+        self.pun: dict[Fascia, list[float]]
+
+    def init(self):
+        self.orari = {
+            Fascia.MONO: 0,
+            Fascia.F1: 0,
+            Fascia.F2: 0,
+            Fascia.F3: 0,
+            Fascia.F23: 0,
+        }
+        self.pun = {
+            Fascia.MONO: [],
+            Fascia.F1: [],
+            Fascia.F2: [],
+            Fascia.F3: [],
+            Fascia.F23: [],
+        }
+
+
+class Fascia(Enum):
+    MONO = "MONO"
+    F1 = "F1"
+    F2 = "F2"
+    F3 = "F3"
+    F23 = "F23"
+
+
+class PunValues:
+    value: dict[Fascia, float]
+    value = {
+        Fascia.MONO: 0.0,
+        Fascia.F1: 0.0,
+        Fascia.F2: 0.0,
+        Fascia.F3: 0.0,
+        Fascia.F23: 0.0,
+    }

--- a/custom_components/pun_sensor/interfaces.py
+++ b/custom_components/pun_sensor/interfaces.py
@@ -3,8 +3,20 @@ from enum import Enum
 
 class PunData:
     def __init__(self) -> None:
-        self.orari: dict[Fascia, int]
-        self.pun: dict[Fascia, list[float]]
+        self.orari = {
+            Fascia.MONO: 0,
+            Fascia.F1: 0,
+            Fascia.F2: 0,
+            Fascia.F3: 0,
+            Fascia.F23: 0,
+        }
+        self.pun = {
+            Fascia.MONO: [],
+            Fascia.F1: [],
+            Fascia.F2: [],
+            Fascia.F3: [],
+            Fascia.F23: [],
+        }
 
     def init(self):
         self.orari = {

--- a/custom_components/pun_sensor/sensor.py
+++ b/custom_components/pun_sensor/sensor.py
@@ -91,22 +91,22 @@ class PUNSensorEntity(CoordinatorEntity, SensorEntity, RestoreEntity):
         # possiamo provare a trasferire i dati o a fixare le statistiche a lungo termine?
         # pros: se si aggiungono sensori o si modificano non va cambiato nulla qua
         # cons: gli id dei sensori cambiano se cambia qualcosa a monte
-        self.entity_id = ENTITY_ID_FORMAT.format(f"pun_{self.fascia.value}")
-        # Disabilitato per testare nuova convenzione, da decidere se cambiarlo o mantenere lo stesso
+        # self.entity_id = ENTITY_ID_FORMAT.format(f"pun_{self.fascia.value}")
+
         # ID univoco sensore basato su un nome fisso
-        # match self.fascia:
-        #     case Fascia.MONO:
-        #         self.entity_id = ENTITY_ID_FORMAT.format("pun_mono_orario")
-        #     case Fascia.F1:
-        #         self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f1")
-        #     case Fascia.F2:
-        #         self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f2")
-        #     case Fascia.F3:
-        #         self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f3")
-        #     case Fascia.F23:
-        #         self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f23")
-        #     case _:
-        #         self.entity_id = "none"
+        match self.fascia:
+            case Fascia.MONO:
+                self.entity_id = ENTITY_ID_FORMAT.format("pun_mono_orario")
+            case Fascia.F1:
+                self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f1")
+            case Fascia.F2:
+                self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f2")
+            case Fascia.F3:
+                self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f3")
+            case Fascia.F23:
+                self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f23")
+            case _:
+                self.entity_id = "none"
         self._attr_unique_id = self.entity_id
         self._attr_has_entity_name = True
 
@@ -284,7 +284,7 @@ class PrezzoFasciaPUNSensorEntity(FasciaPUNSensorEntity, RestoreEntity):
                 self.coordinator.fascia_corrente
             ]
             self._friendly_name = (
-                f"Prezzo fascia corrente (F{self.coordinator.fascia_corrente.value})"
+                f"Prezzo fascia corrente ({self.coordinator.fascia_corrente.value})"
             )
         else:
             self._available = False

--- a/custom_components/pun_sensor/sensor.py
+++ b/custom_components/pun_sensor/sensor.py
@@ -83,7 +83,7 @@ def fmt_float(num: float) -> str:
 class PUNSensorEntity(CoordinatorEntity, SensorEntity, RestoreEntity):
     """Sensore PUN relativo al prezzo medio mensile per fasce."""
 
-    def __init__(self, coordinator: PUNDataUpdateCoordinator, tipo: int) -> None:
+    def __init__(self, coordinator: PUNDataUpdateCoordinator, fascia: Fascia) -> None:
         super().__init__(coordinator)
 
         # Inizializza coordinator e tipo

--- a/custom_components/pun_sensor/sensor.py
+++ b/custom_components/pun_sensor/sensor.py
@@ -85,21 +85,28 @@ class PUNSensorEntity(CoordinatorEntity, SensorEntity, RestoreEntity):
         # Inizializza coordinator e tipo
         self.coordinator = coordinator
         self.fascia = fascia
+
+        # BREAKING CHANGE, NEW ENTITY_ID CONVENTION FOR SENSORS
+        # non so come reagisce HA ad un cambio degli id
+        # possiamo provare a trasferire i dati o a fixare le statistiche a lungo termine?
+        # pros: se si aggiungono sensori o si modificano non va cambiato nulla qua
+        # cons: gli id dei sensori cambiano se cambia qualcosa a monte
+        self.entity_id = ENTITY_ID_FORMAT.format(f"pun_{self.fascia.value}")
+        # Disabilitato per testare nuova convenzione, da decidere se cambiarlo o mantenere lo stesso
         # ID univoco sensore basato su un nome fisso
-        # TODO Switch to Enum interface for fasce
-        match self.tipo:
-            case 0:
-                self.entity_id = ENTITY_ID_FORMAT.format("pun_mono_orario")
-            case 1:
-                self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f1")
-            case 2:
-                self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f2")
-            case 3:
-                self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f3")
-            case 4:
-                self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f23")
-            case _:
-                self.entity_id = "none"
+        # match self.fascia:
+        #     case Fascia.MONO:
+        #         self.entity_id = ENTITY_ID_FORMAT.format("pun_mono_orario")
+        #     case Fascia.F1:
+        #         self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f1")
+        #     case Fascia.F2:
+        #         self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f2")
+        #     case Fascia.F3:
+        #         self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f3")
+        #     case Fascia.F23:
+        #         self.entity_id = ENTITY_ID_FORMAT.format("pun_fascia_f23")
+        #     case _:
+        #         self.entity_id = "none"
         self._attr_unique_id = self.entity_id
         self._attr_has_entity_name = True
 

--- a/custom_components/pun_sensor/sensor.py
+++ b/custom_components/pun_sensor/sensor.py
@@ -1,15 +1,15 @@
 """pun sensor entity"""
 
-# pylint: disable=W0613
+# pylint: disable=W0613, W0601, W0239
 from typing import Any
 
 from awesomeversion.awesomeversion import AwesomeVersion
 
 from homeassistant.components.sensor import (
     ENTITY_ID_FORMAT,
-    SensorDeviceClass,
+    SensorDeviceClass,  # type: ignore #superseeded by HA rules
     SensorEntity,
-    SensorStateClass,
+    SensorStateClass,  # type: ignore #superseeded by HA rules
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CURRENCY_EURO, UnitOfEnergy, __version__ as HA_VERSION

--- a/custom_components/pun_sensor/sensor.py
+++ b/custom_components/pun_sensor/sensor.py
@@ -65,14 +65,10 @@ async def async_setup_entry(
     async_add_entities(entities, update_before_add=False)
 
 
-def decode_fascia(fascia: int | None) -> str | None:
-    return f"F{fascia}"
-
-
-def fmt_float(num: float) -> str:
+def fmt_float(num: float) -> str | float:
     """Formatta adeguatamente il numero decimale."""
     if has_suggested_display_precision:
-        return str(num)
+        return num
 
     # In versioni precedenti di Home Assistant che non supportano
     # l'attributo 'suggested_display_precision' restituisce il numero
@@ -159,7 +155,7 @@ class PUNSensorEntity(CoordinatorEntity, SensorEntity, RestoreEntity):
         return f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}"
 
     @property
-    def state(self) -> str:
+    def state(self) -> str | float:
         return fmt_float(self.native_value)
 
     @property
@@ -329,7 +325,7 @@ class PrezzoFasciaPUNSensorEntity(FasciaPUNSensorEntity, RestoreEntity):
         return f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}"
 
     @property
-    def state(self) -> str:
+    def state(self) -> str | float:
         return fmt_float(self.native_value)
 
     @property

--- a/custom_components/pun_sensor/sensor.py
+++ b/custom_components/pun_sensor/sensor.py
@@ -26,14 +26,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 
 from . import PUNDataUpdateCoordinator
-from .const import (
-    DOMAIN,
-    PUN_FASCIA_F1,
-    PUN_FASCIA_F2,
-    PUN_FASCIA_F3,
-    PUN_FASCIA_F23,
-    PUN_FASCIA_MONO,
-)
+from .const import DOMAIN
+
+from .interfaces import PunValues, Fascia
 
 ATTR_ROUNDED_DECIMALS = "rounded_decimals"
 
@@ -55,13 +50,13 @@ async def async_setup_entry(
         "2023.3.0"
     )
 
-    # Crea i sensori (legati al coordinator)
+    # Crea i sensori dei valori del pun(legati al coordinator)
     entities = []
-    entities.append(PUNSensorEntity(coordinator, PUN_FASCIA_MONO))
-    entities.append(PUNSensorEntity(coordinator, PUN_FASCIA_F23))
-    entities.append(PUNSensorEntity(coordinator, PUN_FASCIA_F1))
-    entities.append(PUNSensorEntity(coordinator, PUN_FASCIA_F2))
-    entities.append(PUNSensorEntity(coordinator, PUN_FASCIA_F3))
+    available_puns = PunValues()
+    for fascia in available_puns.value:
+        entities.append(PUNSensorEntity(coordinator, fascia))
+
+    # crea sensori aggiuntivi
     entities.append(FasciaPUNSensorEntity(coordinator))
     entities.append(PrezzoFasciaPUNSensorEntity(coordinator))
 
@@ -93,8 +88,7 @@ class PUNSensorEntity(CoordinatorEntity, SensorEntity, RestoreEntity):
 
         # Inizializza coordinator e tipo
         self.coordinator = coordinator
-        self.tipo = tipo
-
+        self.fascia = fascia
         # ID univoco sensore basato su un nome fisso
         # TODO Switch to Enum interface for fasce
         match self.tipo:
@@ -122,9 +116,9 @@ class PUNSensorEntity(CoordinatorEntity, SensorEntity, RestoreEntity):
 
     def _handle_coordinator_update(self) -> None:
         """Gestisce l'aggiornamento dei dati dal coordinator."""
-        self._available = self.coordinator.orari[self.tipo] > 0
+        self._available = len(self.coordinator.pun_data.pun[self.fascia]) > 0
         if self._available:
-            self._native_value = self.coordinator.pun[self.tipo]
+            self._native_value = self.coordinator.pun_values.value[self.fascia]
         self.async_write_ha_state()
 
     @property
@@ -176,12 +170,10 @@ class PUNSensorEntity(CoordinatorEntity, SensorEntity, RestoreEntity):
     @property
     def name(self) -> str:
         """Restituisce il nome del sensore"""
-        if self.tipo in [1, 2, 3]:
-            return f"PUN fascia F{self.tipo}"
-        if self.tipo == PUN_FASCIA_MONO:
+        if self.fascia == Fascia.MONO:
             return "PUN mono-orario"
-        if self.tipo == PUN_FASCIA_F23:
-            return "PUN fascia F23"
+        if self.fascia:
+            return f"PUN fascia {self.fascia.value}"
         return "None"
 
     @property
@@ -234,12 +226,16 @@ class FasciaPUNSensorEntity(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> str | None:
         """Restituisce la fascia corrente come stato"""
-        return decode_fascia(self.coordinator.fascia_corrente)
+        if not self.coordinator.fascia_corrente:
+            return "None"
+        return self.coordinator.fascia_corrente.value
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         return {
-            "fascia_successiva": decode_fascia(self.coordinator.fascia_successiva),
+            "fascia_successiva": self.coordinator.fascia_successiva.value
+            if self.coordinator.fascia_successiva
+            else "None",
             "inizio_fascia_successiva": self.coordinator.prossimo_cambio_fascia,
             "termine_fascia_successiva": self.coordinator.termine_prossima_fascia,
         }
@@ -277,22 +273,16 @@ class PrezzoFasciaPUNSensorEntity(FasciaPUNSensorEntity, RestoreEntity):
     def _handle_coordinator_update(self) -> None:
         """Gestisce l'aggiornamento dei dati dal coordinator."""
         if super().available:
-            if self.coordinator.fascia_corrente == 3:
-                self._available = self.coordinator.orari[PUN_FASCIA_F3] > 0
-                self._native_value = self.coordinator.pun[PUN_FASCIA_F3]
-                self._friendly_name = "Prezzo fascia corrente (F3)"
-            elif self.coordinator.fascia_corrente == 2:
-                self._available = self.coordinator.orari[PUN_FASCIA_F2] > 0
-                self._native_value = self.coordinator.pun[PUN_FASCIA_F2]
-                self._friendly_name = "Prezzo fascia corrente (F2)"
-            elif self.coordinator.fascia_corrente == 1:
-                self._available = self.coordinator.orari[PUN_FASCIA_F1] > 0
-                self._native_value = self.coordinator.pun[PUN_FASCIA_F1]
-                self._friendly_name = "Prezzo fascia corrente (F1)"
-            else:
-                self._available = False
-                self._native_value = 0
-                self._friendly_name = "Prezzo fascia corrente"
+            assert self.coordinator.fascia_corrente
+            self._available = (
+                len(self.coordinator.pun_data.pun[self.coordinator.fascia_corrente]) > 0
+            )
+            self._native_value = self.coordinator.pun_values.value[
+                self.coordinator.fascia_corrente
+            ]
+            self._friendly_name = (
+                f"Prezzo fascia corrente (F{self.coordinator.fascia_corrente.value})"
+            )
         else:
             self._available = False
             self._native_value = 0

--- a/custom_components/pun_sensor/utils.py
+++ b/custom_components/pun_sensor/utils.py
@@ -1,3 +1,6 @@
+"""utils"""
+
+# pylint: disable= E1101
 import logging
 from datetime import date, datetime, timedelta
 from zipfile import ZipFile
@@ -36,7 +39,7 @@ def get_fascia(dataora: datetime) -> tuple[int, datetime]:
     """Restituisce la fascia della data/ora indicata (o quella corrente) e la data del prossimo cambiamento."""
 
     # Verifica se la data corrente è un giorno con festività
-    festivo = dataora in holidays.IT()
+    festivo = dataora in holidays.IT()  # type: ignore
 
     # Identifica la fascia corrente
     # F1 = lu-ve 8-19
@@ -130,7 +133,7 @@ def get_next_date(
     )
 
     if feriale:
-        while (prossima in holidays.IT()) or (prossima.weekday() == 6):
+        while (prossima in holidays.IT()) or (prossima.weekday() == 6):  # type: ignore
             prossima += timedelta(days=1)
 
     return prossima
@@ -143,13 +146,7 @@ def extract_xml(archive: ZipFile):
     List[ list[MONO: float], list[F1: float], list[F2: float], list[F3: float] ]
     """
     # Carica le festività
-    it_holidays = holidays.IT()
-
-    # Inizializza le variabili di conteggio dei risultati
-    mono: list[float] = []
-    f1: list[float] = []
-    f2: list[float] = []
-    f3: list[float] = []
+    it_holidays = holidays.IT()  # type: ignore
 
     # Esamina ogni file XML nello ZIP (ordinandoli prima)
     for fn in sorted(archive.namelist()):


### PR DESCRIPTION
New Interfaces and Enums:
-PunData holds the list of values divided by fascia extracted from the xml
-Fascia Enumerates the bands Universally in the code
-PunValues holds the dict of current values for the sensors, this way they are bonded to the enum definition and we can get type checking errors

Main Changes:
Coordinator:
- replaced old for loop with dynamic one using the enum value to set and get pun values, simplified the check and setup of F23
- Removed number of values per pun as a separate dictionary, using len() when needed

Interfaces:
-New file, created Enum and Interfaces nedeed

Sensor:
-replace old static creation with a dynamic loop based on Enum Fascia, this way we can add Bands without having to edit all the various reference
-Replaced definition of self.tipo with self.fascia using

Enum
-Simplified handle_coordinator_update using enum

Utils:
-Updated definitions and type return to Enum Fascia
-Updated return type of exctract_xml to match PunData type
-simplified append match statement with dynamic match